### PR TITLE
Add a docker image for running builds in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-cargo: 
-	xargo build --release --target x86_64-unknown-intermezzos-gnu
+cargo:
+	./run.sh xargo build --release --target x86_64-unknown-intermezzos-gnu
 
 # cargo test fails for some reason, not sure why yet
 test:
@@ -12,7 +12,7 @@ iso: cargo grub.cfg
 	mkdir -p target/isofiles/boot/grub
 	cp grub.cfg target/isofiles/boot/grub
 	cp target/x86_64-unknown-intermezzos-gnu/release/intermezzos target/isofiles/boot/
-	grub-mkrescue -o target/os.iso target/isofiles
+	./run.sh grub-mkrescue -o target/os.iso target/isofiles
 
 run: iso
 	qemu-system-x86_64 -cdrom target/os.iso

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+      xorriso \
+      binutils \
+      nasm \
+      git \
+      qemu \
+      gcc \
+      libc6-dev \
+      curl \
+      ca-certificates \
+      make \
+      sudo \
+      grub-pc \
+      xorriso \
+      grub-common
+
+ENV RUSTUP_HOME=/rustup
+ENV CARGO_HOME=/cargo
+RUN curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+
+ENV PATH=$PATH:/cargo/bin
+RUN cargo install xargo --vers 0.2.1
+RUN rustup component add rust-src

--- a/image/run.sh
+++ b/image/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ "$LOCAL_USER_ID" != "" ]; then
+  useradd --shell /bin/bash -u $LOCAL_USER_ID -o -c "" -m $LOCAL_USER
+  export HOME=/os/target/home
+  export LOCAL_USER_ID=
+  exec sudo -E -u $LOCAL_USER env PATH=$PATH "$@"
+fi
+
+exec "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+docker build --rm -t intermezzos-bare-bones image
+exec docker run \
+  --rm \
+  --volume `pwd`:/os \
+  --env LOCAL_USER=$USER \
+  --env LOCAL_USER_ID=`id -u` \
+  --env TERM=$TERM \
+  --workdir /os \
+  --interactive \
+  --tty \
+  intermezzos-bare-bones \
+  image/run.sh \
+  "$@"


### PR DESCRIPTION
This also adds a few scripts to help out with builds. The standard
`make` and `make run` should basically just do the build inside the
container itself.

Commands like qemu end up running outside the container. Not sure if
this is the exact layout/experience you'd like, but hopefully this helps
as a start!
